### PR TITLE
Add shim solution for deploy keys.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2023 Lettuce Financial Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# empty
+# git-ssh-shim
+
+When using SSH to access git repositories, especially via GitHub, clients will sometimes
+require **multiple** SSH keys:
+
+ - Users may have multiple GitHub accounts, each with different keys, for different
+   GitHub organizations; this scenario is particularly common among contractors and consultants
+   who work with multiple GitHub organizations at once.
+
+ - Automated processes may use GitHub deploy keys -- which must be unique per repository -- and
+   may wish to use the same SSH agent session to access multiple repositories.
+
+Unfortunately, using multiple SSH keys with git (and GitHub) is not straightforward; it's quite
+easy to use a key that is recognized by the provider but not authorized for a specific repository,
+causing the git operation to fail and bypassing the client's normal key negotiation process.
+
+A common solution is to write a _shim_ program that handles key negotiation; this repository
+provides such a program.
+
+
+## Usage
+
+ 1. Download the `git-ssh-shim` shell script.
+
+ 2. Configure your environment to use this script for git ssh operations:
+
+    ```sh
+    export GIT_SSH_COMMAND=/path/to/git-ssh-shim
+    ```
+
+ 3. Use `ssh-agent` (e.g. via `ssh-add`) to add keys you want to use.

--- a/git-ssh-shim
+++ b/git-ssh-shim
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Shim program to negotiate an SSH key using ssh-agent.
+#
+# Based, in part, on discussion in  https://github.com/webfactory/ssh-agent/issues/30
+
+
+# First parse the repository name.
+#
+# The ssh client will pass a string of the form "git-upload-pack 'organization/repository.git'".
+
+for last in ${!#}; do :; done       # extract the final CLI argument
+noquotes=$(echo $last | tr -d "'")  # strip quotes
+base=${noquotes/.git/}              # remove .git
+repo=${base/*\//}                   # remove organization name
+
+# Now create a temporary directory for working with keys.
+key_dir=$(mktemp -d)
+trap "rm -rf $key_dir" EXIT
+
+# Now try each key.
+#
+# We can't run the full ssh command because we'll end up with an ssh protocol error if it fails
+# and the git client will exit before we have a chance to try other keys.
+#
+# We can, however, use `ssh git@github.com` to test connectivity; GitHub will include the matching
+# identity (for a deploy key) in each.
+#
+# TODO: we need a different matching strategy for user keys
+IFS=$'\n'
+for key in $(ssh-add -L); do
+    echo $key > $key_dir/current
+    result=$(ssh -T -i $key_dir/current git@github.com 2>&1)
+
+    if [[ "$result" == *"$repo"* ]]; then
+	mv $key_dir/current $key_dir/key
+    fi
+done
+
+if [ ! -e $key_dir/key ]; then
+    # no matching key
+    exit 1
+fi
+
+# Set ssh options.
+#
+# When using deploy keys, cloning will often fail unless host keys are valid.
+GIT_SSH_OPTIONS=${GIT_SSH_OPTIONS:--o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no}
+
+# Use the key.
+ssh -i $key_dir/key ${GIT_SSH_OPTIONS} $@


### PR DESCRIPTION
Implements (and documents) a git ssh shim script that negotiates keys by running `ssh git@github.com` and checking for a repository match.

Generalizing the matching logic to support user keys will come later.