### PR TITLE
Omit --user marker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ provides such a program.
     If you are using user keys, include your GitHub username in the command:
 
     ```sh
-    export GIT_SSH_COMMAND="$(pwd)/git-ssh-shim --user <github-username>"
+    export GIT_SSH_COMMAND="$(pwd)/git-ssh-shim <github-username>"
     ```
 
  3. Use `ssh-agent` (e.g. via `ssh-add`) to add keys you want to use.

--- a/git-ssh-shim
+++ b/git-ssh-shim
@@ -11,22 +11,15 @@ fi
 # There are two ways we might want to match the ssh key.
 #
 # If we have a user key, we need the GIT_SSH_COMMAND to tell us which user to expect,
-# by adding `--user <github-username>` to the command; the git client will pass these
-# values as the first two CLI arguments.
+# by adding the <github-username> to the command; the git client will pass these values
+# as the first CLI argument.
 #
 # Otherwise, if we have a deploy key, we need to match the key to the repository name.
 
 if [ "$1" != "git@github.com" ]; then
-    # We have extra arguments.
-    if [ "$1" == "--user" ] && [ -n "$2" ]; then
-	# We have --user <github-username>
-
-	needle=$2
-	shift 2
-    else
-	# Unsupported argument
-	exit 1
-    fi
+    # We have extra arguments; assume we have the github username.
+    needle=$1
+    shift
 else
     # We have the repository name.
     #


### PR DESCRIPTION
It's easier to script cases where either user or deploy keys may be used (e.g. Dockerfiles) if we can just inject a single (optional) value.